### PR TITLE
Add docked interface toggle for orbiting menu

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,17 +1,26 @@
 'use client'
 import { Canvas } from '@react-three/fiber'
 import { Stars, OrbitControls } from '@react-three/drei'
-import { Suspense } from 'react'
+import { Suspense, useState } from 'react'
 import * as THREE from 'three'
-import { motion } from 'framer-motion'
+import { AnimatePresence, motion } from 'framer-motion'
 import Globe from '@/components/Globe'
-import OrbitingUI from '@/components/OrbitingUI'
+import OrbitingUI, { ORBIT_ITEMS } from '@/components/OrbitingUI'
 import SceneFX from '@/components/SceneFX'
 import CameraRig from '@/components/camera/CameraRig'
 
 export default function Page() {
+  const [isDocked, setIsDocked] = useState(false)
   return (
     <main className="fixed inset-0 bg-black">
+      <div className="absolute top-6 right-6 z-30 pointer-events-auto">
+        <button
+          onClick={() => setIsDocked((prev) => !prev)}
+          className="px-4 py-2 rounded-full text-sm md:text-base font-semibold tracking-wide border border-cyan-300/60 text-white bg-cardic.blue/30 hover:bg-cardic.blue/50 transition-colors backdrop-blur"
+        >
+          {isDocked ? 'Resume Orbit' : 'Dock Interface'}
+        </button>
+      </div>
       {/* HUD */}
       <div className="absolute inset-x-0 top-0 z-20 flex flex-col items-center p-6 pointer-events-none">
         <motion.h1 initial={{opacity:0,y:-10}} animate={{opacity:1,y:0}} transition={{duration:0.8}}
@@ -20,6 +29,57 @@ export default function Page() {
         </motion.h1>
         <p className="mt-2 text-xs md:text-sm opacity-70">Futuristic Galactic Interface · Space Hub</p>
       </div>
+
+      <AnimatePresence>
+        {isDocked && (
+          <motion.div
+            className="absolute inset-0 z-20 flex"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            <motion.div
+              className="ml-auto mr-8 mt-28 flex flex-col gap-3 pointer-events-auto"
+              initial={{ x: 80, opacity: 0 }}
+              animate={{ x: 0, opacity: 1 }}
+              exit={{ x: 80, opacity: 0 }}
+              transition={{ type: 'spring', stiffness: 80, damping: 16 }}
+            >
+              {ORBIT_ITEMS.map(({ label, href }) => (
+                <motion.a
+                  key={label}
+                  href={href}
+                  target={href && href !== '#' ? '_blank' : undefined}
+                  rel={href && href !== '#' ? 'noreferrer' : undefined}
+                  className="px-5 py-3 rounded-full border border-cyan-300/40 text-sm md:text-base font-semibold tracking-wide text-white/90 bg-black/40 hover:bg-black/60 transition-colors backdrop-blur"
+                  whileHover={{ scale: 1.05 }}
+                  whileTap={{ scale: 0.97 }}
+                >
+                  {label}
+                </motion.a>
+              ))}
+            </motion.div>
+
+            <div className="absolute inset-0 flex items-center justify-center pointer-events-none px-6">
+              <motion.div
+                className="max-w-xl text-center"
+                initial={{ scale: 0.85, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                exit={{ scale: 0.85, opacity: 0 }}
+                transition={{ duration: 0.6, ease: 'easeOut' }}
+              >
+                <motion.p
+                  className="text-xl md:text-3xl lg:text-4xl font-bold text-white tracking-wide drop-shadow-xl"
+                  animate={{ opacity: [0.6, 1, 0.6], scale: [0.98, 1.04, 0.98] }}
+                  transition={{ duration: 3.2, repeat: Infinity }}
+                >
+                  Welcome to Cardic Nexus where smart minds meet.
+                </motion.p>
+              </motion.div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* ThreeJS */}
       <div className="absolute inset-0">
@@ -33,7 +93,7 @@ export default function Page() {
             <Globe />
             <SceneFX />
             <Stars radius={130} depth={80} count={4500} factor={2.6} fade speed={0.4} />
-            <OrbitingUI />
+            <OrbitingUI docked={isDocked} />
           </Suspense>
           <OrbitControls enablePan={false} enableDamping dampingFactor={0.08} minDistance={6} maxDistance={16} />
         </Canvas>

--- a/components/OrbitingUI.tsx
+++ b/components/OrbitingUI.tsx
@@ -5,26 +5,22 @@ import { useFrame } from '@react-three/fiber'
 import { useMemo, useRef, useState } from 'react'
 import { useCameraFocus } from '@/components/camera/store'
 
-const LABELS = [
-  'TOOL','AI MENTOR','CLUB','GAME','COMMUNITY','PROJECTS','AI ANALYST','NEWS','REWARD HUB','ADMIN SEC','ZiRAN'
+export const ORBIT_ITEMS = [
+  { label: 'TOOL', href: '#' },
+  { label: 'AI MENTOR', href: '#' },
+  { label: 'CLUB', href: '#' },
+  { label: 'GAME', href: '#' },
+  { label: 'COMMUNITY', href: 'https://t.me/cardicnexus' },
+  { label: 'PROJECTS', href: '#' },
+  { label: 'AI ANALYST', href: '#' },
+  { label: 'NEWS', href: '#' },
+  { label: 'REWARD HUB', href: '#' },
+  { label: 'ADMIN SEC', href: '#' },
+  { label: 'ZiRAN', href: '#' },
 ]
 
-// Map to your real URLs later
-const LINKS: Record<string,string> = {
-  'TOOL': '#',
-  'AI MENTOR': '#',
-  'CLUB': '#',
-  'GAME': '#',
-  'COMMUNITY': 'https://t.me/cardicnexus',
-  'PROJECTS': '#',
-  'AI ANALYST': '#',
-  'NEWS': '#',
-  'REWARD HUB': '#',
-  'ADMIN SEC': '#',
-  'ZiRAN': '#'
-}
-
-export default function OrbitingUI(){
+export default function OrbitingUI({ docked = false }: { docked?: boolean }){
+  if (docked) return null
   const group = useRef<THREE.Group>(null)
   const t0 = useMemo(()=>Math.random()*1000,[])
   const focus = useCameraFocus(s=>s.focusTo)
@@ -32,7 +28,7 @@ export default function OrbitingUI(){
   useFrame((state)=>{
     const t = state.clock.getElapsedTime() + t0
     if(!group.current) return
-    const L = LABELS.length
+    const L = ORBIT_ITEMS.length
     group.current.children.forEach((child, i)=>{
       const ring = i % 2            // two rings interleaved
       const baseR = 5.0             // wider radius (was ~4.2)
@@ -48,8 +44,8 @@ export default function OrbitingUI(){
 
   return (
     <group ref={group}>
-      {LABELS.map((text)=> (
-        <Button3D key={text} text={text} href={LINKS[text]} onFocus={focus} />
+      {ORBIT_ITEMS.map(({ label, href })=> (
+        <Button3D key={label} text={label} href={href} onFocus={focus} />
       ))}
     </group>
   )


### PR DESCRIPTION
## Summary
- add a HUD toggle button that docks the orbiting interface
- show a right-aligned vertical navigation and animated welcome message while docked
- pause the 3D orbiting UI when the docked state is active

## Testing
- npm run lint *(skipped: command prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d9af6cb8948320a082659d4ea033bc