### PR TITLE
Add external navigation links and coming soon alerts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { Canvas } from '@react-three/fiber'
 import { Stars, OrbitControls } from '@react-three/drei'
-import { Suspense, useState } from 'react'
+import { Suspense, useState, type MouseEvent } from 'react'
 import * as THREE from 'three'
 import { AnimatePresence, motion } from 'framer-motion'
 import Globe from '@/components/Globe'
@@ -11,6 +11,12 @@ import CameraRig from '@/components/camera/CameraRig'
 
 export default function Page() {
   const [isDocked, setIsDocked] = useState(false)
+  const handleDockedClick = (href?: string) => (event: MouseEvent<HTMLAnchorElement>) => {
+    if (!href || href === '#') {
+      event.preventDefault()
+      window.alert('Coming Soon')
+    }
+  }
   return (
     <main className="fixed inset-0 bg-black">
       <div className="absolute top-6 right-6 z-30 pointer-events-auto">
@@ -51,6 +57,7 @@ export default function Page() {
                   href={href}
                   target={href && href !== '#' ? '_blank' : undefined}
                   rel={href && href !== '#' ? 'noreferrer' : undefined}
+                  onClick={handleDockedClick(href)}
                   className="px-5 py-3 rounded-full border border-cyan-300/40 text-sm md:text-base font-semibold tracking-wide text-white/90 bg-black/40 hover:bg-black/60 transition-colors backdrop-blur"
                   whileHover={{ scale: 1.05 }}
                   whileTap={{ scale: 0.97 }}

--- a/components/OrbitingUI.tsx
+++ b/components/OrbitingUI.tsx
@@ -4,20 +4,12 @@ import * as THREE from 'three'
 import { useFrame } from '@react-three/fiber'
 import { useMemo, useRef, useState } from 'react'
 import { useCameraFocus } from '@/components/camera/store'
+import { LABELS, LINKS } from '@/components/data/nav'
 
-export const ORBIT_ITEMS = [
-  { label: 'TOOL', href: '#' },
-  { label: 'AI MENTOR', href: '#' },
-  { label: 'CLUB', href: '#' },
-  { label: 'GAME', href: '#' },
-  { label: 'COMMUNITY', href: 'https://t.me/cardicnexus' },
-  { label: 'PROJECTS', href: '#' },
-  { label: 'AI ANALYST', href: '#' },
-  { label: 'NEWS', href: '#' },
-  { label: 'REWARD HUB', href: '#' },
-  { label: 'ADMIN SEC', href: '#' },
-  { label: 'ZiRAN', href: '#' },
-]
+export const ORBIT_ITEMS = LABELS.map((label) => ({
+  label,
+  href: LINKS[label] ?? '#',
+}))
 
 export default function OrbitingUI({ docked = false }: { docked?: boolean }){
   if (docked) return null
@@ -67,7 +59,13 @@ function Button3D({ text, href, onFocus }:{
           onClick={()=>{
             const p = buttonRef.current?.getWorldPosition(new THREE.Vector3()) ?? new THREE.Vector3(0,0,0)
             onFocus([p.x, p.y, p.z])
-            setTimeout(()=>{ if(href && href !== '#') window.open(href, '_blank') }, 500)
+            setTimeout(()=>{
+              if(href && href !== '#'){
+                window.open(href, '_blank')
+              } else {
+                window.alert('Coming Soon')
+              }
+            }, 500)
           }}
           className={`px-6 md:px-8 py-3 md:py-3.5 rounded-full text-base md:text-lg font-extrabold tracking-wide backdrop-blur border
             ${hover? 'scale-[1.08] shadow-glow' : 'scale-100'}

--- a/components/SidebarMenu.tsx
+++ b/components/SidebarMenu.tsx
@@ -2,9 +2,16 @@
 import { LABELS, LINKS } from '@/components/data/nav'
 import { useUI } from '@/components/ui/store'
 import { motion, AnimatePresence } from 'framer-motion'
+import { type MouseEvent } from 'react'
 
 export default function SidebarMenu(){
   const sidebar = useUI(s=>s.sidebar)
+  const handleLinkClick = (href?: string) => (event: MouseEvent<HTMLAnchorElement>) => {
+    if (!href || href === '#') {
+      event.preventDefault()
+      window.alert('Coming Soon')
+    }
+  }
 
   return (
     <AnimatePresence>
@@ -29,7 +36,8 @@ export default function SidebarMenu(){
                   key={label}
                   href={LINKS[label] || '#'}
                   target={LINKS[label] && LINKS[label] !== '#' ? '_blank' : undefined}
-                  rel="noreferrer"
+                  rel={LINKS[label] && LINKS[label] !== '#' ? 'noreferrer' : undefined}
+                  onClick={handleLinkClick(LINKS[label])}
                   className="block w-full px-4 py-3 rounded-xl
                              border border-cyan-300/30 text-white font-bold
                              bg-gradient-to-r from-cyan-500/25 via-transparent to-violet-500/25

--- a/components/data/nav.ts
+++ b/components/data/nav.ts
@@ -1,11 +1,11 @@
 export const LABELS = [
-  'TOOL','AI MENTOR','CLUB','GAME','COMMUNITY',
+  'TOOLS','TRADING MENTOR','CLUB','GAME','COMMUNITY',
   'PROJECTS','AI ANALYST','NEWS','REWARD HUB','ADMIN SEC','ZiRAN'
 ];
 
 export const LINKS: Record<string,string> = {
-  'TOOL': '#',
-  'AI MENTOR': '#',
+  'TOOLS': 'https://www.cardicnex.us/',
+  'TRADING MENTOR': 'https://cardicworld.vercel.app/',
   'CLUB': '#',
   'GAME': '#',
   'COMMUNITY': 'https://t.me/cardicnexus',


### PR DESCRIPTION
## Summary
- update the navigation data to rename the entries and point Tools and Trading Mentor to their new external URLs
- reuse the shared navigation data for orbiting and docked UI buttons while showing a Coming Soon alert for unfinished sections
- add Coming Soon messaging for sidebar links that do not have real destinations yet

## Testing
- npm run lint *(fails because it prompts for an ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d9bd4beee083209654073e5a4fa2af