### PR TITLE
Refine Space Hub focus drawer interactions

### DIFF
--- a/components/Globe.tsx
+++ b/components/Globe.tsx
@@ -3,16 +3,19 @@ import { useFrame } from '@react-three/fiber'
 import { Sphere } from '@react-three/drei'
 import * as THREE from 'three'
 import { useRef } from 'react'
+import { useUI } from '@/components/ui/store'
 
 export default function Globe() {
   const group = useRef<THREE.Group>(null)
   const wire1 = useRef<THREE.LineSegments>(null)
   const wire2 = useRef<THREE.LineSegments>(null)
+  const animationSpeed = useUI((s) => s.animationSpeed)
 
   useFrame((_, dt) => {
-    if (group.current) group.current.rotation.y += dt * 0.05
-    if (wire1.current) wire1.current.rotation.y += dt * 0.1
-    if (wire2.current) wire2.current.rotation.y -= dt * 0.08
+    const delta = dt * animationSpeed
+    if (group.current) group.current.rotation.y += delta * 0.05
+    if (wire1.current) wire1.current.rotation.y += delta * 0.1
+    if (wire2.current) wire2.current.rotation.y -= delta * 0.08
   })
 
   const R = 2.8

--- a/components/OrbitingUI.tsx
+++ b/components/OrbitingUI.tsx
@@ -5,14 +5,17 @@ import { useFrame } from '@react-three/fiber'
 import { useMemo, useRef, useState } from 'react'
 import { useCameraFocus } from '@/components/camera/store'
 import { LABELS, LINKS } from '@/components/data/nav'
+import { useUI } from '@/components/ui/store'
 
 export default function OrbitingUI(){
   const group = useRef<THREE.Group>(null)
   const t0 = useMemo(()=>Math.random()*1000,[])
-  const focus = useCameraFocus(s=>s.focusTo)
+  const animationSpeed = useUI((s) => s.animationSpeed)
+  const timeRef = useRef(0)
 
-  useFrame((state)=>{
-    const t = state.clock.getElapsedTime() + t0
+  useFrame((state, delta)=>{
+    timeRef.current += delta * animationSpeed
+    const t = timeRef.current + t0
     if(!group.current) return
     const L = LABELS.length
     group.current.children.forEach((child, i)=>{

--- a/components/SidebarMenu.tsx
+++ b/components/SidebarMenu.tsx
@@ -3,46 +3,71 @@ import { LABELS, LINKS } from '@/components/data/nav'
 import { useUI } from '@/components/ui/store'
 import { motion, AnimatePresence } from 'framer-motion'
 
-export default function SidebarMenu(){
-  const sidebar = useUI(s=>s.sidebar)
+export default function SidebarMenu() {
+  const sidebar = useUI((s) => s.sidebar)
+  const setSidebar = useUI((s) => s.setSidebar)
 
   return (
     <AnimatePresence>
       {sidebar && (
         <>
-          <motion.div
-            initial={{ opacity: 0 }} animate={{ opacity: .35 }} exit={{ opacity: 0 }}
-            transition={{ duration: .25 }}
-            className="absolute inset-0 bg-black pointer-events-none z-20"
+          <motion.button
+            type="button"
+            aria-label="Close focus menu"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 0.6 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.25 }}
+            className="fixed inset-0 z-40 bg-black/80 backdrop-blur-sm"
+            onClick={() => setSidebar(false)}
           />
-          <motion.div
-            initial={{ x: 380 }} animate={{ x: 0 }} exit={{ x: 380 }}
-            transition={{ type: 'spring', stiffness: 260, damping: 26 }}
-            className="pointer-events-auto absolute inset-y-0 right-0 z-30 flex items-center"
+          <motion.aside
+            initial={{ x: 360 }}
+            animate={{ x: 0 }}
+            exit={{ x: 360 }}
+            transition={{ type: 'spring', stiffness: 280, damping: 30 }}
+            className="fixed inset-y-0 right-0 z-50 flex w-[min(360px,78vw)] max-w-sm"
+            id="focus-menu"
           >
-            <nav className="mr-6 w-[min(340px,42vw)] max-h-[90vh] overflow-auto
-                            bg-black/50 backdrop-blur rounded-2xl border border-cyan-300/20 p-4 space-y-3">
-              {LABELS.map((label)=> {
-                const url = LINKS[label] || '#'
-                const isReal = url !== '#'
-                return (
-                  <a
-                    key={label}
-                    href={url}
-                    target={isReal ? '_blank' : undefined}
-                    rel={isReal ? 'noreferrer' : undefined}
-                    onClick={(e)=>{ if(!isReal){ e.preventDefault(); alert('Coming soon') }}}
-                    className="block w-full px-4 py-3 rounded-xl
-                               border border-cyan-300/30 text-white font-bold
-                               bg-gradient-to-r from-cyan-500/25 via-transparent to-violet-500/25
-                               shadow-glow hover:scale-[1.02] transition"
-                  >
-                    {label}
-                  </a>
-                )
-              })}
-            </nav>
-          </motion.div>
+            <div className="flex h-full w-full flex-col gap-6 bg-black/80 px-6 pb-10 pt-8 text-white shadow-[0_0_40px_rgba(34,211,238,0.35)]">
+              <header className="flex items-center justify-between">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.4em] text-cyan-300/70">Focus Menu</p>
+                  <h2 className="text-lg font-semibold text-white">Navigate the Nexus</h2>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setSidebar(false)}
+                  className="rounded-full border border-cyan-300/40 px-3 py-1 text-sm font-medium text-white/80 transition hover:border-cyan-200 hover:text-white"
+                >
+                  Close
+                </button>
+              </header>
+              <nav className="flex flex-1 flex-col gap-3 overflow-y-auto pr-1">
+                {LABELS.map((label) => {
+                  const url = LINKS[label] || '#'
+                  const isReal = url !== '#'
+                  return (
+                    <a
+                      key={label}
+                      href={url}
+                      target={isReal ? '_blank' : undefined}
+                      rel={isReal ? 'noreferrer' : undefined}
+                      onClick={(event) => {
+                        if (!isReal) {
+                          event.preventDefault()
+                          alert('Coming soon')
+                        }
+                      }}
+                      className="rounded-xl border border-cyan-300/30 bg-gradient-to-r from-cyan-500/20 via-transparent to-violet-500/20 px-4 py-3 font-semibold tracking-wide text-white transition hover:scale-[1.02] hover:border-cyan-200/70 hover:shadow-[0_0_25px_rgba(34,211,238,0.35)]"
+                    >
+                      {label}
+                    </a>
+                  )
+                })}
+              </nav>
+            </div>
+          </motion.aside>
         </>
       )}
     </AnimatePresence>

--- a/components/WelcomeCenter.tsx
+++ b/components/WelcomeCenter.tsx
@@ -2,29 +2,26 @@
 import { motion } from 'framer-motion'
 import { useUI } from '@/components/ui/store'
 
-export default function WelcomeCenter(){
-  const sidebar = useUI(s=>s.sidebar)
-  if(!sidebar) return null
+export default function WelcomeCenter() {
+  const sidebar = useUI((s) => s.sidebar)
 
   return (
-    <div className="pointer-events-none absolute inset-0 flex items-center justify-center z-20">
+    <div className="pointer-events-none absolute inset-0 z-30 flex items-center justify-center px-6">
       <motion.div
-        initial={{ opacity: 0, scale: .95 }}
-        animate={{ opacity: 1, scale: 1 }}
-        transition={{ duration: .6 }}
-        className="text-center"
+        initial={false}
+        animate={{ opacity: sidebar ? 0 : 1, y: sidebar ? 16 : 0, scale: sidebar ? 0.97 : 1 }}
+        transition={{ duration: 0.35, ease: 'easeOut' }}
+        className="max-w-3xl text-center"
       >
-        <motion.div
-          animate={{ textShadow: ['0 0 0px #00ffff', '0 0 18px #00ffff', '0 0 0px #00ffff'] }}
-          transition={{ duration: 2, repeat: Infinity }}
-          className="text-2xl md:text-5xl font-extrabold tracking-wide
-                     bg-clip-text text-transparent bg-gradient-to-r from-cyan-400 to-violet-400 drop-shadow"
+        <h2
+          className="text-[clamp(2.2rem,6vw,3.8rem)] font-semibold tracking-[0.12em] text-white"
+          style={{ textShadow: '0 0 22px rgba(56,189,248,0.45)' }}
         >
-          Welcome to Cardic Nexus
-        </motion.div>
-        <div className="mt-3 text-sm md:text-lg opacity-80">
-          where smart minds meet
-        </div>
+          Cardic Nexus — Space Hub
+        </h2>
+        <p className="mt-4 text-[clamp(0.95rem,2.8vw,1.25rem)] font-medium text-white/80">
+          Build bold ideas with stellar teams, guided by mentors, tools, and funding aligned to your orbit.
+        </p>
       </motion.div>
     </div>
   )

--- a/components/data/nav.ts
+++ b/components/data/nav.ts
@@ -1,18 +1,10 @@
-export const LABELS = [
-  'TOOL','AI MENTOR','CLUB','GAME','COMMUNITY',
-  'PROJECTS','AI ANALYST','NEWS','REWARD HUB','ADMIN SEC','ZiRAN'
-];
+export const LABELS = ['AI Mentor', 'Tools', 'Club', 'Game', 'Funding', 'NexLink']
 
-export const LINKS: Record<string,string> = {
-  'TOOL': 'https://www.cardicnex.us/',
-  'AI MENTOR': 'https://cardicworld.vercel.app/',
-  'CLUB': '#',
-  'GAME': '#',
-  'COMMUNITY': '#',
-  'PROJECTS': '#',
-  'AI ANALYST': '#',
-  'NEWS': '#',
-  'REWARD HUB': '#',
-  'ADMIN SEC': '#',
-  'ZiRAN': '#'
-};
+export const LINKS: Record<string, string> = {
+  'AI Mentor': 'https://cardicworld.vercel.app/',
+  Tools: 'https://www.cardicnex.us/',
+  Club: '#',
+  Game: '#',
+  Funding: '#',
+  NexLink: '#',
+}

--- a/components/ui/Toggle.tsx
+++ b/components/ui/Toggle.tsx
@@ -5,11 +5,12 @@ export default function Toggle(){
   const { sidebar, toggleSidebar } = useUI()
   return (
     <button
+      type="button"
       onClick={toggleSidebar}
-      className="pointer-events-auto absolute top-5 right-6 z-30 px-4 py-2 rounded-full border border-cyan-300/40
-                 bg-gradient-to-r from-cyan-500/20 via-transparent to-violet-500/20
-                 text-white font-semibold shadow-glow hover:scale-[1.05] transition"
+      className="pointer-events-auto fixed top-6 right-6 z-50 rounded-full border border-cyan-300/50 bg-gradient-to-r from-cyan-500/25 via-transparent to-violet-500/25 px-5 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-white shadow-[0_0_20px_rgba(14,165,233,0.35)] transition hover:scale-105 hover:border-cyan-200/80"
       aria-pressed={sidebar}
+      aria-expanded={sidebar}
+      aria-controls="focus-menu"
     >
       {sidebar ? 'Back to Orbit' : 'Focus Menu'}
     </button>

--- a/components/ui/store.ts
+++ b/components/ui/store.ts
@@ -3,11 +3,27 @@ import { create } from 'zustand'
 
 type UIStore = {
   sidebar: boolean
+  animationSpeed: number
   toggleSidebar: () => void
-  setSidebar: (v:boolean)=>void
+  setSidebar: (v: boolean) => void
+  setAnimationSpeed: (speed: number) => void
 }
-export const useUI = create<UIStore>((set)=>({
+
+export const useUI = create<UIStore>((set) => ({
   sidebar: false,
-  toggleSidebar: ()=>set(s=>({ sidebar: !s.sidebar })),
-  setSidebar: (v)=>set({ sidebar: v })
+  animationSpeed: 1,
+  toggleSidebar: () =>
+    set((state) => {
+      const sidebar = !state.sidebar
+      return {
+        sidebar,
+        animationSpeed: sidebar ? 0 : 1,
+      }
+    }),
+  setSidebar: (v) =>
+    set({
+      sidebar: v,
+      animationSpeed: v ? 0 : 1,
+    }),
+  setAnimationSpeed: (speed) => set({ animationSpeed: speed }),
 }))

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,3 +1,5 @@
 /// <reference types="next" />
-/// <reference types="next/navigation-types/compat/navigation" />
-/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
## Summary
- add shared animation speed state that synchronizes the globe and orbiting UI motion with the focus drawer visibility
- redesign the focus menu button and sidebar drawer so they sit above the scene, present the new menu options, and provide clear close affordances
- refresh the center copy with single-layer glow text that scales responsively for a cleaner presentation

## Testing
- npm run lint *(prompts for ESLint setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdb0ea5ec832087dec9a2b464b9f8