### PR TITLE
Polish focus toggle accessibility and spacing

### DIFF
--- a/components/WelcomeCenter.tsx
+++ b/components/WelcomeCenter.tsx
@@ -17,10 +17,10 @@ export default function WelcomeCenter() {
           className="text-[clamp(2.2rem,6vw,3.8rem)] font-semibold tracking-[0.12em] text-white"
           style={{ textShadow: '0 0 22px rgba(56,189,248,0.45)' }}
         >
-          Cardic Nexus — Space Hub
+          Cardic Nexus — TRADING HUB
         </h2>
-        <p className="mt-4 text-[clamp(0.95rem,2.8vw,1.25rem)] font-medium text-white/80">
-
+        <p className="mt-4 text-[clamp(0.95rem,2.8vw,1.25rem)] font-medium tracking-[0.38em] text-white/70">
+          FIRST TRADING ECOSYSTEM
         </p>
       </motion.div>
     </div>

--- a/components/ui/Toggle.tsx
+++ b/components/ui/Toggle.tsx
@@ -1,19 +1,31 @@
 'use client'
+
 import { useUI } from './store'
 
 export default function Toggle() {
   const { sidebar, toggleSidebar } = useUI()
+  const label = sidebar ? 'Back to Orbit' : 'Focus Menu'
+  const ariaLabel = sidebar ? 'Return to orbit view' : 'Open focus menu'
+  const topOffset = 'calc(env(safe-area-inset-top, 0px) + clamp(3.25rem, 11vw, 5rem))'
+
   return (
     <button
       type="button"
       onClick={toggleSidebar}
- fixed top-6 right-6 z-50 rounded-full border border-cyan-300/50 bg-gradient-to-r from-cyan-500/25 via-transparent to-violet-500/25 px-5 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-white shadow-[0_0_20px_rgba(14,165,233,0.35)] transition hover:scale-105 hover:border-cyan-200/80"
-
+      className="pointer-events-auto fixed z-50 inline-flex min-h-[3.25rem] min-w-[11.5rem] items-center justify-center rounded-full border border-cyan-300/50 bg-gradient-to-r from-cyan-500/25 via-transparent to-violet-500/25 px-7 py-3 text-[0.85rem] font-semibold uppercase tracking-[0.28em] text-white shadow-[0_0_24px_rgba(14,165,233,0.38)] backdrop-blur-sm transition hover:scale-[1.03] hover:border-cyan-200/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+      style={{
+        right: 'calc(env(safe-area-inset-right, 0px) + clamp(0.85rem, 3vw, 2.5rem))',
+        top: topOffset,
+      }}
       aria-pressed={sidebar}
       aria-expanded={sidebar}
       aria-controls="focus-menu"
+      aria-label={ariaLabel}
+      aria-haspopup="dialog"
     >
-      {sidebar ? 'Back to Orbit' : 'Focus Menu'}
+      <span aria-live="polite" className="whitespace-nowrap">
+        {label}
+      </span>
     </button>
   )
 }


### PR DESCRIPTION
## Summary
- enlarge and reposition the focus toggle for better safe-area spacing and mobile tap targets
- add accessible labeling improvements to the focus toggle when opening the focus menu

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0babe2c1483209d6b08d2f62d2811