### PR TITLE
Embed mentor and tools apps in internal shell

### DIFF
--- a/app/apps/[slug]/page.tsx
+++ b/app/apps/[slug]/page.tsx
@@ -1,0 +1,46 @@
+import ExternalAppFrame from "@/components/ExternalAppFrame"
+
+const ALLOWLIST: Record<string, string> = {
+  mentor: "https://cardicworld.vercel.app/",
+  tools: "https://www.cardicnex.us/",
+}
+
+type AppShellPageProps = {
+  params: {
+    slug: string
+  }
+}
+
+export default function AppShellPage({ params }: AppShellPageProps) {
+  const slug = params.slug
+  const url = ALLOWLIST[slug]
+
+  const title = `Cardic • ${slug}`
+
+  return (
+    <main className="flex min-h-screen flex-col bg-black text-white">
+      <header className="flex h-16 items-center justify-between border-b border-cyan-300/30 bg-black/80 px-6 backdrop-blur">
+        <a href="/" className="text-xs font-semibold uppercase tracking-[0.5em] text-white/80 hover:text-white">
+          Cardic Nexus
+        </a>
+        <span className="text-[0.65rem] uppercase tracking-[0.4em] text-cyan-200/70">Apps</span>
+      </header>
+      <div className="flex-1 bg-black">
+        {url ? (
+          <ExternalAppFrame src={url} title={title} />
+        ) : (
+          <div className="flex h-[calc(100vh-64px)] w-full flex-col items-center justify-center gap-2 text-center">
+            <p className="text-lg font-semibold">Unknown app.</p>
+            <p className="text-sm text-white/70">Check the URL or return to the hub.</p>
+            <a
+              href="/"
+              className="mt-3 rounded-full border border-cyan-300/60 px-6 py-2 text-sm font-semibold uppercase tracking-[0.3em] text-cyan-100 transition hover:border-cyan-200 hover:text-white"
+            >
+              Back to hub
+            </a>
+          </div>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/components/ExternalAppFrame.tsx
+++ b/components/ExternalAppFrame.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+type ExternalAppFrameProps = {
+  src: string
+  title?: string
+}
+
+export default function ExternalAppFrame({ src, title }: ExternalAppFrameProps) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isBlocked, setIsBlocked] = useState(false)
+
+  useEffect(() => {
+    if (!isLoading) {
+      return
+    }
+
+    const timeout = window.setTimeout(() => {
+      setIsBlocked(true)
+      setIsLoading(false)
+    }, 6000)
+
+    return () => {
+      window.clearTimeout(timeout)
+    }
+  }, [isLoading])
+
+  useEffect(() => {
+    const iframe = iframeRef.current
+    if (!iframe) {
+      return
+    }
+
+    const sendTheme = () => {
+      const theme = document.documentElement.className
+      const targetWindow = iframe.contentWindow
+      if (!targetWindow) return
+
+      try {
+        targetWindow.postMessage(
+          {
+            type: "cardic-theme",
+            value: theme,
+          },
+          "*",
+        )
+      } catch (error) {
+        // ignored
+      }
+    }
+
+    sendTheme()
+    const interval = window.setInterval(sendTheme, 5000)
+
+    return () => {
+      window.clearInterval(interval)
+    }
+  }, [src])
+
+  return (
+    <div className="relative h-[calc(100vh-64px)] w-full">
+      {!isBlocked && (
+        <iframe
+          ref={iframeRef}
+          src={src}
+          title={title}
+          className="h-full w-full border-0"
+          sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-downloads"
+          referrerPolicy="strict-origin-when-cross-origin"
+          onLoad={() => {
+            setIsLoading(false)
+            setIsBlocked(false)
+          }}
+        />
+      )}
+
+      {isLoading && !isBlocked && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/70">
+          <div className="flex flex-col items-center gap-3 text-white">
+            <span className="h-12 w-12 animate-spin rounded-full border-4 border-cyan-300/40 border-t-transparent" />
+            <p className="text-sm uppercase tracking-[0.4em] text-cyan-200/80">Initializing app…</p>
+          </div>
+        </div>
+      )}
+
+      {isBlocked && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-4 bg-black/80 px-6 text-center text-white">
+          <div>
+            <p className="text-lg font-semibold">This app can’t be embedded.</p>
+            <p className="mt-2 text-sm text-white/70">
+              It blocked loading inside the Cardic Nexus shell. Open it in a new tab to continue.
+            </p>
+          </div>
+          <a
+            href={src}
+            target="_blank"
+            rel="noreferrer"
+            className="rounded-full border border-cyan-300/60 px-6 py-2 text-sm font-semibold uppercase tracking-[0.3em] text-cyan-100 transition hover:border-cyan-200 hover:text-white"
+          >
+            Open in new tab
+          </a>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/OrbitingUI.tsx
+++ b/components/OrbitingUI.tsx
@@ -7,6 +7,7 @@ import { useMemo, useRef, useState } from 'react'
 import { useCameraFocus } from '@/components/camera/store'
 import { LABELS, LINKS } from '@/components/data/nav'
 import { useUI } from '@/components/ui/store'
+import { useRouter } from 'next/navigation'
 
 export default function OrbitingUI(){
   const group = useRef<THREE.Group>(null)
@@ -45,15 +46,21 @@ function Button3D({ text, href }:{ text:string, href:string }){
   const [hover, setHover] = useState(false)
   const buttonRef = useRef<THREE.Group>(null)
   const focus = useCameraFocus(s=>s.focusTo)
+  const router = useRouter()
 
   const handleClick = ()=>{
     const p = buttonRef.current?.getWorldPosition(new THREE.Vector3()) ?? new THREE.Vector3(0,0,0)
     focus([p.x, p.y, p.z])
     setTimeout(()=>{
-      if (href && href !== '#') {
+      if (!href || href === '#') {
+        alert('Coming soon')
+        return
+      }
+
+      if (/^https?:\/\//.test(href)) {
         window.open(href, '_blank')
       } else {
-        alert('Coming soon')
+        router.push(href)
       }
     }, 400)
   }

--- a/components/SidebarMenu.tsx
+++ b/components/SidebarMenu.tsx
@@ -1,4 +1,5 @@
 'use client'
+import Link from 'next/link'
 import { LABELS, LINKS } from '@/components/data/nav'
 import { useUI } from '@/components/ui/store'
 import { motion, AnimatePresence } from 'framer-motion'
@@ -46,23 +47,48 @@ export default function SidebarMenu() {
               <nav className="flex flex-1 flex-col gap-3 overflow-y-auto pr-1">
                 {LABELS.map((label) => {
                   const url = LINKS[label] || '#'
-                  const isReal = url !== '#'
+                  const isDisabled = url === '#'
+                  const isExternal = /^https?:\/\//.test(url)
+
+                  const className =
+                    'rounded-xl border border-cyan-300/30 bg-gradient-to-r from-cyan-500/20 via-transparent to-violet-500/20 px-4 py-3 font-semibold tracking-wide text-white transition hover:scale-[1.02] hover:border-cyan-200/70 hover:shadow-[0_0_25px_rgba(34,211,238,0.35)]'
+
+                  if (isDisabled) {
+                    return (
+                      <button
+                        key={label}
+                        type="button"
+                        onClick={() => alert('Coming soon')}
+                        className={className}
+                      >
+                        {label}
+                      </button>
+                    )
+                  }
+
+                  if (isExternal) {
+                    return (
+                      <a
+                        key={label}
+                        href={url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className={className}
+                      >
+                        {label}
+                      </a>
+                    )
+                  }
+
                   return (
-                    <a
+                    <Link
                       key={label}
                       href={url}
-                      target={isReal ? '_blank' : undefined}
-                      rel={isReal ? 'noreferrer' : undefined}
-                      onClick={(event) => {
-                        if (!isReal) {
-                          event.preventDefault()
-                          alert('Coming soon')
-                        }
-                      }}
-                      className="rounded-xl border border-cyan-300/30 bg-gradient-to-r from-cyan-500/20 via-transparent to-violet-500/20 px-4 py-3 font-semibold tracking-wide text-white transition hover:scale-[1.02] hover:border-cyan-200/70 hover:shadow-[0_0_25px_rgba(34,211,238,0.35)]"
+                      onClick={() => setSidebar(false)}
+                      className={className}
                     >
                       {label}
-                    </a>
+                    </Link>
                   )
                 })}
               </nav>

--- a/components/data/nav.ts
+++ b/components/data/nav.ts
@@ -1,8 +1,7 @@
 export const LABELS = ['AI Mentor', 'Tools', 'Club', 'Game', 'Funding', 'NexLink']
-
 export const LINKS: Record<string, string> = {
-  'AI Mentor': 'https://cardicworld.vercel.app/',
-  Tools: 'https://www.cardicnex.us/',
+  'AI Mentor': '/apps/mentor',
+  Tools: '/apps/tools',
   Club: '#',
   Game: '#',
   Funding: '#',


### PR DESCRIPTION
## Summary
- add a reusable ExternalAppFrame client component that handles loading, blocking, and theme messaging for embedded apps
- create the /apps/[slug] route to allowlist mentor/tools URLs and surface an unknown app fallback while preserving the site header
- update AI Mentor and Tools buttons to route internally through the new shell without altering their styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e190a8b5188320993d95c640cf8776