### PR TITLE
Expand embedded app workspace to full viewport

### DIFF
--- a/app/apps/[slug]/page.tsx
+++ b/app/apps/[slug]/page.tsx
@@ -1,0 +1,61 @@
+import SiteHeader from '@/components/SiteHeader'
+import SidebarMenu from '@/components/SidebarMenu'
+import ExternalAppFrame from '@/components/ExternalAppFrame'
+import { APP_ALLOWLIST } from '@/lib/externalApps'
+import { notFound } from 'next/navigation'
+
+interface ExternalAppPageProps {
+  params: {
+    slug: string
+  }
+}
+
+export function generateMetadata({ params }: ExternalAppPageProps) {
+  const app = APP_ALLOWLIST[params.slug]
+
+  if (!app) {
+    return {}
+  }
+
+  return {
+    title: `${app.name} — CARDIC NEXUS`,
+    description: `Docked experience for ${app.name} inside the CARDIC Space Hub.`,
+  }
+}
+
+export default function ExternalAppPage({ params }: ExternalAppPageProps) {
+  const app = APP_ALLOWLIST[params.slug]
+
+  if (!app) {
+    notFound()
+  }
+
+  return (
+    <main className="relative flex min-h-[100dvh] w-full flex-col overflow-hidden bg-black text-white">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(34,211,238,0.25),transparent_55%)]" aria-hidden />
+
+      <SiteHeader />
+
+      <div
+        className="relative z-10 flex flex-1 min-h-0 flex-col"
+        style={{
+          paddingTop: 'calc(env(safe-area-inset-top, 0px) + 6.5rem)',
+          paddingLeft: 'env(safe-area-inset-left, 0px)',
+          paddingRight: 'env(safe-area-inset-right, 0px)',
+          paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 1.5rem)',
+        }}
+      >
+        <div className="flex flex-col gap-2 px-4 pb-4 sm:px-6 lg:px-10">
+          <p className="text-xs uppercase tracking-[0.4em] text-cyan-200/70">Docked Application</p>
+          <h1 className="text-2xl font-semibold text-white sm:text-3xl">{app.name}</h1>
+        </div>
+
+        <div className="flex flex-1 min-h-0 flex-col px-4 sm:px-6 lg:px-10">
+          <ExternalAppFrame src={app.url} title={app.name} />
+        </div>
+      </div>
+
+      <SidebarMenu />
+    </main>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,30 +8,14 @@ import { Stars } from '@react-three/drei'
 
 import OrbitingUI from '@/components/OrbitingUI'
 import SidebarMenu from '@/components/SidebarMenu'
-import Toggle from '@/components/ui/Toggle'
+import SiteHeader from '@/components/SiteHeader'
 import WelcomeCenter from '@/components/WelcomeCenter'
 
 export default function Page() {
   return (
     <main className="relative min-h-screen w-full overflow-hidden bg-black text-white">
       {/* HUD / Header */}
-      <header
-        className="pointer-events-none absolute inset-x-0 top-0 z-40 mx-auto flex max-w-7xl items-start justify-between px-4 sm:px-6"
-        style={{
-          paddingTop: 'calc(env(safe-area-inset-top, 0px) + 1rem)',
-          paddingLeft: 'calc(env(safe-area-inset-left, 0px) + 1rem)',
-          paddingRight: 'calc(env(safe-area-inset-right, 0px) + 1rem)',
-        }}
-      >
-        <h1
-          className="pointer-events-auto mt-[clamp(0.75rem,6vw,2rem)] select-none text-[clamp(1.05rem,4.5vw,1.4rem)] font-extrabold tracking-[0.42em] max-[480px]:mt-[clamp(3rem,14vw,3.75rem)] max-[480px]:tracking-[0.3em] max-[480px]:pl-[calc(env(safe-area-inset-left,0px)+0.25rem)] sm:mt-0 sm:text-2xl sm:tracking-[0.6em]"
-        >
-          CARDIC NEXUS
-        </h1>
-        <div className="pointer-events-auto">
-          <Toggle />
-        </div>
-      </header>
+      <SiteHeader />
 
       {/* 3D Scene */}
       <div className="absolute inset-0">

--- a/components/ExternalAppFrame.tsx
+++ b/components/ExternalAppFrame.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+interface ExternalAppFrameProps {
+  src: string
+  title: string
+}
+
+const BLOCK_TIMEOUT = 8000
+
+export default function ExternalAppFrame({ src, title }: ExternalAppFrameProps) {
+  const [isLoading, setIsLoading] = useState(true)
+  const [isBlocked, setIsBlocked] = useState(false)
+  const timeoutRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    setIsLoading(true)
+    setIsBlocked(false)
+
+    if (timeoutRef.current) {
+      window.clearTimeout(timeoutRef.current)
+    }
+
+    timeoutRef.current = window.setTimeout(() => {
+      setIsBlocked(true)
+      setIsLoading(false)
+    }, BLOCK_TIMEOUT)
+
+    return () => {
+      if (timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current)
+      }
+    }
+  }, [src])
+
+  const handleLoad = () => {
+    if (timeoutRef.current) {
+      window.clearTimeout(timeoutRef.current)
+    }
+    setIsLoading(false)
+    setIsBlocked(false)
+  }
+
+  const handleError = () => {
+    if (timeoutRef.current) {
+      window.clearTimeout(timeoutRef.current)
+    }
+    setIsBlocked(true)
+    setIsLoading(false)
+  }
+
+  return (
+    <div className="relative h-full w-full flex-1 min-h-0">
+      {!isBlocked && (
+        <iframe
+          key={src}
+          src={src}
+          title={title}
+          onLoad={handleLoad}
+          onError={handleError}
+          className="block h-full w-full bg-transparent"
+          allow="clipboard-write; fullscreen; accelerometer; magnetometer; gyroscope"
+          sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
+          referrerPolicy="strict-origin-when-cross-origin"
+          allowFullScreen
+        />
+      )}
+
+      {isLoading && !isBlocked && (
+        <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-black/70 backdrop-blur">
+          <div className="flex flex-col items-center gap-3 text-cyan-100">
+            <span className="h-10 w-10 animate-spin rounded-full border-2 border-cyan-200/40 border-t-cyan-200" aria-hidden />
+            <p className="text-sm font-medium tracking-wide text-cyan-100/80">Connecting to {title}…</p>
+          </div>
+        </div>
+      )}
+
+      {isBlocked && (
+        <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-4 border border-cyan-400/40 bg-black/80 p-8 text-center text-cyan-50">
+          <p className="text-base font-semibold">We couldn't display {title} inside Space Hub.</p>
+          <p className="text-sm text-cyan-100/70">
+            The app may block embedding in other sites. You can still open it in a new tab to continue.
+          </p>
+          <a
+            href={src}
+            target="_blank"
+            rel="noreferrer"
+            className="rounded-full border border-cyan-300/60 bg-cyan-500/20 px-6 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-white transition hover:border-cyan-100 hover:bg-cyan-500/35"
+          >
+            Open in new tab
+          </a>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/OrbitingUI.tsx
+++ b/components/OrbitingUI.tsx
@@ -7,6 +7,7 @@ import { useMemo, useRef, useState } from 'react'
 import { useCameraFocus } from '@/components/camera/store'
 import { LABELS, LINKS } from '@/components/data/nav'
 import { useUI } from '@/components/ui/store'
+import { useRouter } from 'next/navigation'
 
 export default function OrbitingUI(){
   const group = useRef<THREE.Group>(null)
@@ -45,15 +46,21 @@ function Button3D({ text, href }:{ text:string, href:string }){
   const [hover, setHover] = useState(false)
   const buttonRef = useRef<THREE.Group>(null)
   const focus = useCameraFocus(s=>s.focusTo)
+  const router = useRouter()
 
   const handleClick = ()=>{
     const p = buttonRef.current?.getWorldPosition(new THREE.Vector3()) ?? new THREE.Vector3(0,0,0)
     focus([p.x, p.y, p.z])
     setTimeout(()=>{
-      if (href && href !== '#') {
-        window.open(href, '_blank')
-      } else {
+      if (!href || href === '#') {
         alert('Coming soon')
+        return
+      }
+
+      if (href.startsWith('/')) {
+        router.push(href)
+      } else {
+        window.open(href, '_blank')
       }
     }, 400)
   }

--- a/components/SidebarMenu.tsx
+++ b/components/SidebarMenu.tsx
@@ -2,6 +2,7 @@
 import { LABELS, LINKS } from '@/components/data/nav'
 import { useUI } from '@/components/ui/store'
 import { motion, AnimatePresence } from 'framer-motion'
+import Link from 'next/link'
 
 export default function SidebarMenu() {
   const sidebar = useUI((s) => s.sidebar)
@@ -46,19 +47,39 @@ export default function SidebarMenu() {
               <nav className="flex flex-1 flex-col gap-3 overflow-y-auto pr-1">
                 {LABELS.map((label) => {
                   const url = LINKS[label] || '#'
-                  const isReal = url !== '#'
+                  if (url === '#') {
+                    return (
+                      <button
+                        key={label}
+                        type="button"
+                        onClick={() => alert('Coming soon')}
+                        className="rounded-xl border border-cyan-300/30 bg-gradient-to-r from-cyan-500/20 via-transparent to-violet-500/20 px-4 py-3 text-left font-semibold tracking-wide text-white transition hover:scale-[1.02] hover:border-cyan-200/70 hover:shadow-[0_0_25px_rgba(34,211,238,0.35)]"
+                      >
+                        {label}
+                      </button>
+                    )
+                  }
+
+                  if (url.startsWith('/')) {
+                    return (
+                      <Link
+                        key={label}
+                        href={url}
+                        onClick={() => setSidebar(false)}
+                        className="rounded-xl border border-cyan-300/30 bg-gradient-to-r from-cyan-500/20 via-transparent to-violet-500/20 px-4 py-3 font-semibold tracking-wide text-white transition hover:scale-[1.02] hover:border-cyan-200/70 hover:shadow-[0_0_25px_rgba(34,211,238,0.35)]"
+                      >
+                        {label}
+                      </Link>
+                    )
+                  }
+
                   return (
                     <a
                       key={label}
                       href={url}
-                      target={isReal ? '_blank' : undefined}
-                      rel={isReal ? 'noreferrer' : undefined}
-                      onClick={(event) => {
-                        if (!isReal) {
-                          event.preventDefault()
-                          alert('Coming soon')
-                        }
-                      }}
+                      target="_blank"
+                      rel="noreferrer"
+                      onClick={() => setSidebar(false)}
                       className="rounded-xl border border-cyan-300/30 bg-gradient-to-r from-cyan-500/20 via-transparent to-violet-500/20 px-4 py-3 font-semibold tracking-wide text-white transition hover:scale-[1.02] hover:border-cyan-200/70 hover:shadow-[0_0_25px_rgba(34,211,238,0.35)]"
                     >
                       {label}

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import Toggle from '@/components/ui/Toggle'
+
+export default function SiteHeader() {
+  return (
+    <header
+      className="pointer-events-none absolute inset-x-0 top-0 z-40 mx-auto flex max-w-7xl items-start justify-between px-4 sm:px-6"
+      style={{
+        paddingTop: 'calc(env(safe-area-inset-top, 0px) + 1rem)',
+        paddingLeft: 'calc(env(safe-area-inset-left, 0px) + 1rem)',
+        paddingRight: 'calc(env(safe-area-inset-right, 0px) + 1rem)',
+      }}
+    >
+      <h1
+        className="pointer-events-auto mt-[clamp(0.75rem,6vw,2rem)] select-none text-[clamp(1.05rem,4.5vw,1.4rem)] font-extrabold tracking-[0.42em] max-[480px]:mt-[clamp(3rem,14vw,3.75rem)] max-[480px]:tracking-[0.3em] max-[480px]:pl-[calc(env(safe-area-inset-left,0px)+0.25rem)] sm:mt-0 sm:text-2xl sm:tracking-[0.6em]"
+      >
+        CARDIC NEXUS
+      </h1>
+      <div className="pointer-events-auto">
+        <Toggle />
+      </div>
+    </header>
+  )
+}

--- a/components/data/nav.ts
+++ b/components/data/nav.ts
@@ -1,8 +1,8 @@
 export const LABELS = ['AI Mentor', 'Tools', 'Club', 'Game', 'Funding', 'NexLink']
 
 export const LINKS: Record<string, string> = {
-  'AI Mentor': 'https://cardicworld.vercel.app/',
-  Tools: 'https://www.cardicnex.us/',
+  'AI Mentor': '/apps/mentor',
+  Tools: '/apps/tools',
   Club: '#',
   Game: '#',
   Funding: '#',

--- a/lib/externalApps.ts
+++ b/lib/externalApps.ts
@@ -1,0 +1,10 @@
+export const APP_ALLOWLIST: Record<string, { name: string; url: string }> = {
+  mentor: {
+    name: 'AI Mentor',
+    url: 'https://cardicworld.vercel.app/',
+  },
+  tools: {
+    name: 'Tools',
+    url: 'https://www.cardicnex.us/',
+  },
+}


### PR DESCRIPTION
## Summary
- stretch the `/apps/[slug]` surface to occupy the entire viewport beneath the hub header with safe-area padding
- simplify `ExternalAppFrame` chrome so embedded experiences render edge-to-edge while keeping loading and fallback overlays intact

## Testing
- npm run lint *(prompts for initial ESLint setup, command aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68e1939689d08320bc673ea672399bf1