### PR TITLE
Render external apps in plain iframe and add error fallbacks

### DIFF
--- a/app/apps/[slug]/error.tsx
+++ b/app/apps/[slug]/error.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { useEffect } from "react"
+
+export default function ExternalAppError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-black px-6 text-center text-white">
+      <h1 className="text-2xl font-bold">Unable to load app</h1>
+      <p className="max-w-md text-sm text-white/70">
+        We hit a snag while loading this external experience. Please try again.
+      </p>
+      <button
+        onClick={() => reset()}
+        className="rounded-full border border-cyan-300/60 bg-cyan-500/20 px-5 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-white transition hover:border-cyan-100 hover:bg-cyan-500/35"
+      >
+        Retry
+      </button>
+    </div>
+  )
+}

--- a/app/apps/[slug]/page.tsx
+++ b/app/apps/[slug]/page.tsx
@@ -1,4 +1,3 @@
- // app/apps/[slug]/page.tsx
 import ExternalAppFrame from "@/components/ExternalAppFrame"
 import { APP_ALLOWLIST } from "@/lib/app-allowlist"
 import { notFound } from "next/navigation"
@@ -16,9 +15,5 @@ export default function ExternalAppPage({ params }: ExternalAppPageProps) {
     notFound()
   }
 
-  return (
-    <div className="fixed inset-0 h-screen w-screen overflow-hidden bg-black text-white">
-      <ExternalAppFrame src={app.url} title={app.name} />
-    </div>
-  )
+  return <ExternalAppFrame src={app.url} title={app.name} />
 }

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { useEffect } from "react"
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    console.error(error)
+  }, [error])
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-black px-6 text-center text-white">
+      <h1 className="text-2xl font-bold">Something went wrong</h1>
+      <p className="max-w-md text-sm text-white/70">
+        An unexpected error occurred. You can try again, or navigate back to the home screen.
+      </p>
+      <button
+        onClick={() => reset()}
+        className="rounded-full border border-cyan-300/60 bg-cyan-500/20 px-5 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-white transition hover:border-cyan-100 hover:bg-cyan-500/35"
+      >
+        Try again
+      </button>
+    </div>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,6 +7,10 @@ html, body, #__next { height: 100%; }
 * { box-sizing: border-box; }
 body { margin: 0; background: #000; color: #fff; overflow: hidden; }
 
+body.external-app-view {
+  overflow: auto;
+}
+
 /* Subtle vignette + color haze */
 .nebula-vignette {
   pointer-events: none;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,13 @@
 // app/page.tsx
 
+import dynamic from "next/dynamic";
 import SiteHeader from "@/components/SiteHeader";
-
 import SidebarMenu from "@/components/SidebarMenu";
-
 import WelcomeCenter from "@/components/WelcomeCenter";
 
-import OrbitingUI from "@/components/OrbitingUI";
+const OrbitingUI = dynamic(() => import("@/components/OrbitingUI"), {
+  ssr: false,
+});
 
 export default function HomePage() {
 

--- a/components/ExternalAppFrame.tsx
+++ b/components/ExternalAppFrame.tsx
@@ -1,96 +1,20 @@
-'use client'
-
-import { useEffect, useRef, useState } from 'react'
+"use client"
 
 interface ExternalAppFrameProps {
   src: string
   title: string
 }
 
-const BLOCK_TIMEOUT = 8000
-
 export default function ExternalAppFrame({ src, title }: ExternalAppFrameProps) {
-  const [isLoading, setIsLoading] = useState(true)
-  const [isBlocked, setIsBlocked] = useState(false)
-  const timeoutRef = useRef<number | null>(null)
-
-  useEffect(() => {
-    setIsLoading(true)
-    setIsBlocked(false)
-
-    if (timeoutRef.current) {
-      window.clearTimeout(timeoutRef.current)
-    }
-
-    timeoutRef.current = window.setTimeout(() => {
-      setIsBlocked(true)
-      setIsLoading(false)
-    }, BLOCK_TIMEOUT)
-
-    return () => {
-      if (timeoutRef.current) {
-        window.clearTimeout(timeoutRef.current)
-      }
-    }
-  }, [src])
-
-  const handleLoad = () => {
-    if (timeoutRef.current) {
-      window.clearTimeout(timeoutRef.current)
-    }
-    setIsLoading(false)
-    setIsBlocked(false)
-  }
-
-  const handleError = () => {
-    if (timeoutRef.current) {
-      window.clearTimeout(timeoutRef.current)
-    }
-    setIsBlocked(true)
-    setIsLoading(false)
-  }
-
   return (
-    <div className="relative h-full w-full">
-      {!isBlocked && (
-        <iframe
-          key={src}
-          src={src}
-          title={title}
-          onLoad={handleLoad}
-          onError={handleError}
-          className="block h-full w-full"
-          allow="fullscreen"
-          sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
-          referrerPolicy="strict-origin-when-cross-origin"
-        />
-      )}
-
-      {isLoading && !isBlocked && (
-        <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-black/70">
-          <div className="flex flex-col items-center gap-3 text-cyan-100">
-            <span className="h-10 w-10 animate-spin rounded-full border-2 border-cyan-200/40 border-t-cyan-200" aria-hidden />
-            <p className="text-sm font-medium tracking-wide text-cyan-100/80">Connecting to {title}…</p>
-          </div>
-        </div>
-      )}
-
-      {isBlocked && (
-        <div className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-4 bg-black/80 px-6 text-center text-cyan-50">
-          <p className="text-base font-semibold">We couldn't display {title} inside Space Hub.</p>
-          <p className="text-sm text-cyan-100/70">
-            The app may block embedding in other sites. You can still open it in a new tab to continue.
-          </p>
-          <a
-            href={src}
-            target="_blank"
-            rel="noreferrer"
-            className="rounded-full border border-cyan-300/60 bg-cyan-500/20 px-6 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-white transition hover:border-cyan-100 hover:bg-cyan-500/35"
-          >
-            Open in new tab
-          </a>
-        </div>
-      )}
-    </div>
+    <iframe
+      src={src}
+      title={title}
+      allow="fullscreen"
+      allowFullScreen
+      className="block h-screen w-screen border-0"
+      sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
+      referrerPolicy="strict-origin-when-cross-origin"
+    />
   )
 }

--- a/components/ExternalAppShell.tsx
+++ b/components/ExternalAppShell.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { useEffect } from 'react'
+import ExternalAppFrame from '@/components/ExternalAppFrame'
+import { useUI } from '@/components/ui/store'
+
+interface ExternalAppShellProps {
+  src: string
+  title: string
+}
+
+export default function ExternalAppShell({ src, title }: ExternalAppShellProps) {
+  const setSidebar = useUI((s) => s.setSidebar)
+  const setAnimationSpeed = useUI((s) => s.setAnimationSpeed)
+
+  useEffect(() => {
+    // Ensure the orbit UI is reset when leaving the hub experience.
+    setSidebar(false)
+    setAnimationSpeed(1)
+  }, [setAnimationSpeed, setSidebar])
+
+  useEffect(() => {
+    const { body } = document
+    const previousOverflow = body.style.overflow
+
+    body.classList.add('external-app-view')
+    body.style.overflow = 'auto'
+
+    return () => {
+      body.classList.remove('external-app-view')
+      body.style.overflow = previousOverflow
+    }
+  }, [])
+
+  return (
+    <div className="fixed inset-0 h-screen w-screen overflow-hidden bg-black text-white">
+      <ExternalAppFrame src={src} title={title} />
+    </div>
+  )
+}

--- a/components/OrbitingUI.tsx
+++ b/components/OrbitingUI.tsx
@@ -1,86 +1,110 @@
 // @ts-nocheck
-'use client'
-import { Html } from '@react-three/drei'
-import * as THREE from 'three'
-import { useFrame } from '@react-three/fiber'
-import { useMemo, useRef, useState } from 'react'
-import { useCameraFocus } from '@/components/camera/store'
-import { LABELS, LINKS } from '@/components/data/nav'
-import { useUI } from '@/components/ui/store'
-import { useRouter } from 'next/navigation'
+"use client"
+import { Suspense, useMemo, useRef, useState } from "react"
+import { Canvas, useFrame } from "@react-three/fiber"
+import { Html } from "@react-three/drei"
+import * as THREE from "three"
+import SceneFX from "@/components/SceneFX"
+import { useCameraFocus } from "@/components/camera/store"
+import { LABELS, LINKS } from "@/components/data/nav"
+import { useUI } from "@/components/ui/store"
+import { useRouter } from "next/navigation"
 
-export default function OrbitingUI(){
+export default function OrbitingUI() {
+  return (
+    <Canvas
+      className="fixed inset-0 -z-10"
+      camera={{ position: [0, 0, 12], fov: 45, near: 0.1, far: 100 }}
+      gl={{ alpha: true }}
+    >
+      <color attach="background" args={["#000000"]} />
+      <ambientLight intensity={0.55} />
+      <directionalLight position={[6, 4, 4]} intensity={0.6} />
+      <Suspense fallback={null}>
+        <SceneFX />
+        <OrbitButtons />
+      </Suspense>
+    </Canvas>
+  )
+}
+
+function OrbitButtons() {
   const group = useRef<THREE.Group>(null)
-  const t0 = useMemo(()=>Math.random()*1000,[])
+  const t0 = useMemo(() => Math.random() * 1000, [])
   const animationSpeed = useUI((s) => s.animationSpeed)
   const timeRef = useRef(0)
 
-  useFrame((state, delta)=>{
+  useFrame((_, delta) => {
     timeRef.current += delta * animationSpeed
     const t = timeRef.current + t0
-    if(!group.current) return
+    if (!group.current) return
     const L = LABELS.length
-    group.current.children.forEach((child, i)=>{
+    group.current.children.forEach((child, i) => {
       const ring = i % 2
       const baseR = 5.0
       const r = baseR + (ring ? 0.8 : -0.2)
-      const speed = 0.22 + (i*0.017)
-      const phase = (i*(Math.PI*2/L)) + (ring ? Math.PI/L : 0)
-      const a = t*speed + phase
-      const y = Math.sin(t*0.45 + i)*0.45
-      child.position.set(Math.cos(a)*r, y, Math.sin(a)*r)
-      child.lookAt(0,0,0)
+      const speed = 0.22 + i * 0.017
+      const phase = (i * (Math.PI * 2) / L) + (ring ? Math.PI / L : 0)
+      const a = t * speed + phase
+      const y = Math.sin(t * 0.45 + i) * 0.45
+      child.position.set(Math.cos(a) * r, y, Math.sin(a) * r)
+      child.lookAt(0, 0, 0)
     })
   })
 
   return (
     <group ref={group}>
-      {LABELS.map((text)=> (
-        <Button3D key={text} text={text} href={LINKS[text] || '#'} />
+      {LABELS.map((text) => (
+        <OrbitButton key={text} text={text} href={LINKS[text] || "#"} />
       ))}
     </group>
   )
 }
 
-function Button3D({ text, href }:{ text:string, href:string }){
+function OrbitButton({ text, href }: { text: string; href: string }) {
   const [hover, setHover] = useState(false)
   const buttonRef = useRef<THREE.Group>(null)
-  const focus = useCameraFocus(s=>s.focusTo)
+  const focus = useCameraFocus((s) => s.focusTo)
   const router = useRouter()
+  const setSidebar = useUI((s) => s.setSidebar)
+  const baseClasses =
+    "px-6 md:px-8 py-3 md:py-3.5 rounded-full text-base md:text-lg font-extrabold tracking-wide backdrop-blur border transition-all duration-200 border-cyan-300/40 text-white bg-gradient-to-r from-cardic.blue/35 via-transparent to-cardic.violet/35"
 
-  const handleClick = ()=>{
-    const p = buttonRef.current?.getWorldPosition(new THREE.Vector3()) ?? new THREE.Vector3(0,0,0)
-    focus([p.x, p.y, p.z])
-    setTimeout(()=>{
-      if (!href || href === '#') {
-        alert('Coming soon')
-        return
-      }
+  const handleClick = () => {
+    if (!href || href === "#") {
+      const p = buttonRef.current?.getWorldPosition(new THREE.Vector3()) ?? new THREE.Vector3(0, 0, 0)
+      focus([p.x, p.y, p.z])
+      alert("Coming soon")
+      return
+    }
 
-      if (href.startsWith('/')) {
-        router.push(href)
-      } else {
-        window.open(href, '_blank')
-      }
-    }, 400)
+    setSidebar(false)
+
+    if (href.startsWith("/")) {
+      router.push(href)
+    } else {
+      window.open(href, "_blank")
+    }
   }
 
   return (
     <group ref={buttonRef}>
       <Html center occlude distanceFactor={8} sprite>
-        <button
-          onMouseEnter={()=>setHover(true)}
-          onMouseLeave={()=>setHover(false)}
-          onClick={handleClick}
-          className={`px-6 md:px-8 py-3 md:py-3.5 rounded-full text-base md:text-lg font-extrabold tracking-wide backdrop-blur border
-            ${hover? 'scale-[1.08] shadow-glow' : 'scale-100'}
-            transition-all duration-200
-            border-cyan-300/40 text-white
-            bg-gradient-to-r from-cardic.blue/35 via-transparent to-cardic.violet/35`}
-          style={{ boxShadow: hover? '0 0 28px rgba(34,211,238,0.55), 0 0 60px rgba(139,92,246,0.4)' : '0 0 14px rgba(14,165,233,0.18)'}}
-        >
-          {text}
-        </button>
+        <div className="pointer-events-auto">
+          <button
+            onMouseEnter={() => setHover(true)}
+            onMouseLeave={() => setHover(false)}
+            onClick={handleClick}
+            className={`${baseClasses} ${hover ? "scale-[1.08] shadow-glow" : "scale-100"}`}
+            style={{
+              boxShadow: hover
+                ? "0 0 28px rgba(34,211,238,0.55), 0 0 60px rgba(139,92,246,0.4)"
+                : "0 0 14px rgba(14,165,233,0.18)",
+            }}
+          >
+            {text}
+          </button>
+        </div>
       </Html>
     </group>
   )


### PR DESCRIPTION
## Summary
- render /apps/[slug] pages with the streamlined ExternalAppFrame client iframe for a clean fullscreen embed
- wrap OrbitingUI in a Canvas so all R3F hooks run inside the fiber context while keeping the animated orbit buttons interactive
- add global and per-app route error boundaries to show a retry affordance when client errors occur

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e24ab1d7008320bad409091c808de9